### PR TITLE
Feature: Post and comment likes

### DIFF
--- a/backend/src/routes/api.js
+++ b/backend/src/routes/api.js
@@ -3,10 +3,12 @@ import db from '../database/database-connection.js';
 import {
   randomPost,
   randomComment,
+  randomPostLike,
 } from '../database/database-seeding/utils/fake-data-generators.js';
 import {
   insertPost,
   insertComment,
+  insertPostLike,
 } from '../database/database-seeding/utils/sql-queries.js';
 
 const router = express.Router();
@@ -112,6 +114,29 @@ router.post('/comment', async (req, res) => {
     message: 'Comment Payload recieved and added to database.',
     dataSaved: comment,
   });
+});
+
+router.post('/postLike', async (req, res) => {
+  const { postID, userID, liked } = req.body;
+  console.log(req.body);
+
+  let postLike = randomPostLike(userID, postID, true);
+
+  if (liked) {
+    await db.execute(insertPostLike(postLike));
+    res.send({
+      message: 'Post like Payload recieved and added to database.',
+      dataSaved: postLike,
+    });
+  } else {
+    await db.execute(
+      `DELETE from postLike WHERE postID="${postID}" AND userID="${userID}"`,
+    );
+    res.send({
+      message: 'Post like Payload recieved and deleted from database.',
+      dataSaved: postLike,
+    });
+  }
 });
 
 export default router;

--- a/backend/src/routes/api.js
+++ b/backend/src/routes/api.js
@@ -4,11 +4,13 @@ import {
   randomPost,
   randomComment,
   randomPostLike,
+  randomCommentLike,
 } from '../database/database-seeding/utils/fake-data-generators.js';
 import {
   insertPost,
   insertComment,
   insertPostLike,
+  insertCommentLike,
 } from '../database/database-seeding/utils/sql-queries.js';
 
 const router = express.Router();
@@ -135,6 +137,29 @@ router.post('/postLike', async (req, res) => {
     res.send({
       message: 'Post like Payload recieved and deleted from database.',
       dataSaved: postLike,
+    });
+  }
+});
+
+router.post('/commentLike', async (req, res) => {
+  const { postCommentID, userID, liked } = req.body;
+  console.log(req.body);
+
+  let commentLike = randomCommentLike(userID, postCommentID, true);
+
+  if (liked) {
+    await db.execute(insertCommentLike(commentLike));
+    res.send({
+      message: 'Comment like Payload recieved and added to database.',
+      dataSaved: commentLike,
+    });
+  } else {
+    await db.execute(
+      `DELETE from commentLike WHERE postCommentID="${postCommentID}" AND userID="${userID}"`,
+    );
+    res.send({
+      message: 'Comment like Payload recieved and deleted from database.',
+      dataSaved: commentLike,
     });
   }
 });

--- a/frontend/src/Components/Comment/Comment.css
+++ b/frontend/src/Components/Comment/Comment.css
@@ -22,14 +22,26 @@
   display: flex;
   gap: var(--gap-lg);
   padding-left: var(--pd-sm);
+  margin-top: 4px;
 }
 
-.Comment_Button_Container > a {
-  color: var(--bg-primary);
-  filter: brightness(0.5);
+.Comment_Button_Container_Btn {
+  background-color: transparent;
+  padding: 0;
+  min-width: auto;
+  max-width: auto;
+  color: #95989b;
   font-family: 'Klavika-medium';
 }
 
-.Comment_Button_Container > a:nth-of-type(3) {
+.Comment_Button_Container_Btn:hover {
+  text-decoration: underline;
+}
+
+.Comment_Button_Container_Btn:nth-of-type(3) {
   font-family: 'klavika-light';
+}
+
+.color_blue {
+  color: var(--blue-300);
 }

--- a/frontend/src/Components/Comment/Comment.jsx
+++ b/frontend/src/Components/Comment/Comment.jsx
@@ -68,11 +68,24 @@ const Comment = ({ commentData, userID, setFetchPosts }) => {
           <div className='Comment_Text_Body'>{commentText}</div>
         </div>
         <div className='Comment_Button_Container'>
-          <a href='http://localhost:3000'>likes {commentLikes.length}</a>
-          <a href='http://localhost:3000'>Reply</a>
-          <a href='http://localhost:3000'>
+          <button
+            type='button'
+            className={
+              isCommentLiked
+                ? 'Comment_Button_Container_Btn color_blue'
+                : 'Comment_Button_Container_Btn'
+            }
+            onClick={handleLikeClick}
+          >
+            {' '}
+            {`like (${commentLikes.length})`}
+          </button>
+          <button type='button' className='Comment_Button_Container_Btn'>
+            Reply
+          </button>
+          <button type='button' className='Comment_Button_Container_Btn'>
             {moment(createdDateTime).fromNow()}
-          </a>
+          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/Components/Comment/Comment.jsx
+++ b/frontend/src/Components/Comment/Comment.jsx
@@ -1,14 +1,58 @@
 import './Comment.css';
-import React from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import moment from 'moment';
+import axios from 'axios';
 import PropTypes from 'prop-types';
 import NavBubble from '../NavBubble/NavBubble';
 
-const Comment = ({ commentData }) => {
-  const { commentUserData, commentLikes, commentText, createdDateTime } =
-    commentData;
+const Comment = ({ commentData, userID, setFetchPosts }) => {
+  //
+  // State
+  const [isCommentLiked, setIsCommentLiked] = useState(false);
+  const [postCommentData, setPostCommentData] = useState(false);
+  const isMounted = useRef(false);
+
+  const {
+    commentUserData,
+    postCommentID,
+    commentLikes,
+    commentText,
+    createdDateTime,
+  } = commentData;
 
   const { firstName, lastName, profilePicture } = commentUserData[0];
+
+  const handleLikeClick = () => {
+    setIsCommentLiked((prev) => !prev);
+    setPostCommentData(true);
+  };
+
+  const submitCommentLike = async () => {
+    const commentLikeURL = 'http://localhost:8080/api/commentLike';
+
+    const commentLikeData = {
+      postCommentID,
+      userID,
+      liked: isCommentLiked,
+    };
+
+    try {
+      const response = await axios.post(commentLikeURL, commentLikeData);
+      setFetchPosts(true);
+      console.log(response.data.message);
+    } catch (err) {
+      if (err) throw err;
+    }
+  };
+
+  useEffect(() => {
+    if (isMounted.current && postCommentData) {
+      submitCommentLike();
+      setPostCommentData(false);
+    } else {
+      isMounted.current = true;
+    }
+  }, [isCommentLiked]);
 
   return (
     <div className='Comment_Container'>
@@ -38,10 +82,13 @@ const Comment = ({ commentData }) => {
 Comment.propTypes = {
   commentData: PropTypes.shape({
     commentUserData: PropTypes.array.isRequired,
+    postCommentID: PropTypes.string.isRequired,
     commentLikes: PropTypes.array.isRequired,
     commentText: PropTypes.string.isRequired,
     createdDateTime: PropTypes.string.isRequired,
   }).isRequired,
+  userID: PropTypes.string.isRequired,
+  setFetchPosts: PropTypes.func.isRequired,
 };
 
 export default Comment;

--- a/frontend/src/Components/Post/Post.jsx
+++ b/frontend/src/Components/Post/Post.jsx
@@ -14,7 +14,7 @@ const Post = ({ postData, user, setFetchPosts }) => {
   //
   // State
   const [commentInputOpen, setCommentInputOpen] = useState(false);
-  const [postLiked, setPostLiked] = useState(false);
+  const [isPostLiked, setIsPostLiked] = useState(false);
   const [isMounted, setIsMounted] = useState(false);
 
   const {
@@ -35,7 +35,7 @@ const Post = ({ postData, user, setFetchPosts }) => {
     const postLikeData = {
       postID: postData.postID,
       userID: user.userID,
-      liked: postLiked,
+      liked: isPostLiked,
     };
 
     try {
@@ -53,9 +53,9 @@ const Post = ({ postData, user, setFetchPosts }) => {
     } else {
       setIsMounted(true);
     }
-  }, [postLiked]);
+  }, [isPostLiked]);
 
-  const handleLikeClick = () => setPostLiked((prev) => !prev);
+  const handleLikeClick = () => setIsPostLiked((prev) => !prev);
   const handleCommentClick = () => setCommentInputOpen((prev) => !prev);
 
   return (
@@ -84,11 +84,11 @@ const Post = ({ postData, user, setFetchPosts }) => {
           <img
             src={likeIcon}
             alt='thumbs up'
-            className={postLiked ? 'filterBlue' : ''}
+            className={isPostLiked ? 'filterBlue' : ''}
           />
           <span
             className={
-              postLiked
+              isPostLiked
                 ? ' Post_Reactions_Text filterBlue'
                 : 'Post_Reactions_Text'
             }

--- a/frontend/src/Components/Post/Post.jsx
+++ b/frontend/src/Components/Post/Post.jsx
@@ -1,5 +1,5 @@
 import './Post.css';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import moment from 'moment';
 import axios from 'axios';
 import PropTypes from 'prop-types';
@@ -15,7 +15,8 @@ const Post = ({ postData, user, setFetchPosts }) => {
   // State
   const [commentInputOpen, setCommentInputOpen] = useState(false);
   const [isPostLiked, setIsPostLiked] = useState(false);
-  const [isMounted, setIsMounted] = useState(false);
+  const [sendPostData, setSendPostData] = useState(false);
+  const isMounted = useRef(false);
 
   const {
     postText,
@@ -48,14 +49,18 @@ const Post = ({ postData, user, setFetchPosts }) => {
   };
 
   useEffect(() => {
-    if (isMounted) {
+    if (isMounted.current && sendPostData) {
       submitPostLike();
+      setSendPostData(false);
     } else {
-      setIsMounted(true);
+      isMounted.current = true;
     }
   }, [isPostLiked]);
 
-  const handleLikeClick = () => setIsPostLiked((prev) => !prev);
+  const handleLikeClick = () => {
+    setIsPostLiked((prev) => !prev);
+    setSendPostData(true);
+  };
   const handleCommentClick = () => setCommentInputOpen((prev) => !prev);
 
   return (
@@ -112,7 +117,13 @@ const Post = ({ postData, user, setFetchPosts }) => {
       <hr />
       <div className='Post_Comments_Container'>
         {commentData.map((comment) => (
-          <Comment commentData={comment} key={comment.postCommentID} />
+          <Comment
+            commentData={comment}
+            key={comment.postCommentID}
+            postID={postData.postID}
+            userID={user.userID}
+            setFetchPosts={setFetchPosts}
+          />
         ))}
         {commentInputOpen && (
           <CommentInput

--- a/frontend/src/Components/Post/Post.jsx
+++ b/frontend/src/Components/Post/Post.jsx
@@ -1,6 +1,7 @@
 import './Post.css';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import moment from 'moment';
+import axios from 'axios';
 import PropTypes from 'prop-types';
 import NavBubble from '../NavBubble/NavBubble';
 import Comment from '../Comment/Comment';
@@ -13,6 +14,8 @@ const Post = ({ postData, user, setFetchPosts }) => {
   //
   // State
   const [commentInputOpen, setCommentInputOpen] = useState(false);
+  const [postLiked, setPostLiked] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
 
   const {
     postText,
@@ -26,7 +29,34 @@ const Post = ({ postData, user, setFetchPosts }) => {
 
   const numPostLikes = expandedPostLikeData.length;
 
-  const handleClick = () => setCommentInputOpen((prev) => !prev);
+  const submitPostLike = async () => {
+    const postLikeURL = 'http://localhost:8080/api/postLike';
+
+    const postLikeData = {
+      postID: postData.postID,
+      userID: user.userID,
+      liked: postLiked,
+    };
+
+    try {
+      const response = await axios.post(postLikeURL, postLikeData);
+      setFetchPosts(true);
+      console.log(response.data.message);
+    } catch (err) {
+      if (err) throw err;
+    }
+  };
+
+  useEffect(() => {
+    if (isMounted) {
+      submitPostLike();
+    } else {
+      setIsMounted(true);
+    }
+  }, [postLiked]);
+
+  const handleLikeClick = () => setPostLiked((prev) => !prev);
+  const handleCommentClick = () => setCommentInputOpen((prev) => !prev);
 
   return (
     <div className='Post'>

--- a/frontend/src/Components/Post/Post.jsx
+++ b/frontend/src/Components/Post/Post.jsx
@@ -76,14 +76,30 @@ const Post = ({ postData, user, setFetchPosts }) => {
       </div>
       <hr />
       <div className='Post_Reactions_Container'>
-        <div className='Post_Reaction_Text_Container'>
-          <img src={likeIcon} alt='thumbs up' />
-          <span className='Post_Reactions_Text'>Like</span>
-        </div>
         <button
           type='button'
-          onClick={handleClick}
           className='Post_Reaction_Comment_Btn'
+          onClick={handleLikeClick}
+        >
+          <img
+            src={likeIcon}
+            alt='thumbs up'
+            className={postLiked ? 'filterBlue' : ''}
+          />
+          <span
+            className={
+              postLiked
+                ? ' Post_Reactions_Text filterBlue'
+                : 'Post_Reactions_Text'
+            }
+          >
+            Like
+          </span>
+        </button>
+        <button
+          type='button'
+          className='Post_Reaction_Comment_Btn'
+          onClick={handleCommentClick}
         >
           <img src={commentIcon} alt='speach bubble' />
           <span className='Post_Reactions_Text'>Comment</span>

--- a/frontend/src/routes/root.jsx
+++ b/frontend/src/routes/root.jsx
@@ -20,7 +20,6 @@ const Root = () => {
     (async () => {
       const response = await fetchUser();
       if (response && response.data) {
-        console.log('User', response.data);
         setUser(response.data);
         setIsLoggedIn('true');
       }


### PR DESCRIPTION
## Description & motivation
Added a feature that allows users to like/unlike posts and comments on posts when clicking on the post/comment like buttons. This like/unlike is reflected in the respective postLike/postCommentLike database tables. At the moment each like or unlike hits that database with a query which is not ideal, but for the sake of development progress I am tabling this issue until the app is more complete at which point I will revisit these components for further optimization.

## Checklist:

<!---
This checklist is mostly useful as a reminder of small things that can easily be
forgotten – it is meant as a helpful tool rather than hoops to jump through.
Put an `x` in all the items that apply, make notes next to any that haven't been
addressed, and remove any items that are not relevant to this PR.
-->

- [x] My pull request represents one logical piece of work.
- [x] My commits are related to the pull request and look clean.
- [x] I have updated the README file.
- [x] Have you added an explanation of what your changes do and why you'd like to include them?

## Screenshots (if appropriate):
![ezgif com-gif-maker (14)](https://user-images.githubusercontent.com/49503056/203176625-bc1581d2-5d8f-4d55-9de5-b1769bbe4d2c.gif)
